### PR TITLE
Fix: don't try to load blank texture files

### DIFF
--- a/read_ascii_xps.py
+++ b/read_ascii_xps.py
@@ -117,6 +117,9 @@ def readMeshes(file, hasBones):
             # print('Texture file', textureFile)
             uvLayerId = ascii_ops.readInt(file)
 
+            if not textureFile:
+                continue
+
             xpsTexture = xps_types.XpsTexture(texId, textureFile, uvLayerId)
             textures.append(xpsTexture)
 

--- a/xps_tools.py
+++ b/xps_tools.py
@@ -131,6 +131,12 @@ class Import_Xps_Model_Op(bpy.types.Operator, ImportHelper):
         description="Import Custom Normals",
         default=True,
     )
+    
+    separateByCollection: bpy.props.BoolProperty(
+        name="Aggregate Optional Items",
+        description="Dedicate special collections for optional items",
+        default=True,
+    )
 
     # Only needed if you want to add into a dynamic menu
     def menu_func(self, context):
@@ -156,7 +162,8 @@ class Import_Xps_Model_Op(bpy.types.Operator, ImportHelper):
             self.vColors,
             self.connectBones,
             self.autoIk,
-            self.importNormals
+            self.importNormals,
+            self.separateByCollection
         )
         material_creator.create_group_nodes()
         status = import_xnalara_model.getInputFilename(xpsSettings)
@@ -180,6 +187,7 @@ class Import_Xps_Model_Op(bpy.types.Operator, ImportHelper):
         col.label(text='Mesh')
         col.prop(self, "joinMeshParts")
         col.prop(self, "joinMeshRips")
+        col.prop(self, "separateByCollection")
         sub = col.row()
         sub.prop(self, "markSeams")
         col.prop(self, "importNormals")

--- a/xps_types.py
+++ b/xps_types.py
@@ -114,7 +114,8 @@ class XpsImportSettings:
             vColors,
             connectBones,
             autoIk,
-            importNormals):
+            importNormals,
+            separateByCollection):
         self.filename = filename
         self.uvDisplX = uvDisplX
         self.uvDisplY = uvDisplY
@@ -126,6 +127,7 @@ class XpsImportSettings:
         self.connectBones = connectBones
         self.autoIk = autoIk
         self.importNormals = importNormals
+        self.separateByCollection = separateByCollection
 
 
 class XpsExportSettings:


### PR DESCRIPTION
When a .ascii lists # textures but leave it blank, the addon treat those blank spaces as the "file's" name.  
Later when creating the materials, these blanks would error. 
This change skips adding the blank textures to the list of textures that are loaded later.