### PR TITLE
Fix: don't try to load blank texture files

### DIFF
--- a/read_ascii_xps.py
+++ b/read_ascii_xps.py
@@ -117,6 +117,9 @@ def readMeshes(file, hasBones):
             # print('Texture file', textureFile)
             uvLayerId = ascii_ops.readInt(file)
 
+            if not textureFile:
+                continue
+
             xpsTexture = xps_types.XpsTexture(texId, textureFile, uvLayerId)
             textures.append(xpsTexture)
 


### PR DESCRIPTION
When a .ascii lists # textures but leave it blank, the addon treat those blank spaces as the "file's" name.
Later when creating the materials, these blanks would error.
This change skips adding the blank textures to the list of textures that are loaded later.