### PR TITLE
Update material_creator.py

### DIFF
--- a/material_creator.py
+++ b/material_creator.py
@@ -185,7 +185,7 @@ def makeNodesMaterial(xpsSettings, materialData, rootDir, mesh_da, meshInfo, fla
     coordNode.location = xpsShadeNode.location + Vector((-2500, 400))
 
     if useAlpha:
-        materialData.blend_method = 'BLEND'
+        materialData.blend_method = 'HASHED'
 
     node_tree.links.new(xpsShadeNode.outputs['Shader'], ouputNode.inputs['Surface'])
 


### PR DESCRIPTION
There are EEVEE issues reported by many users because EEVEE is handling the transparency a little bit strange.
IMO the default setting should be "HASHED" when importing, a value that does not cause any problems with the display of transparency.

The instructions may contain information about which transparency settings can be changed for individual objects in order to set a better but possibly unstable display/render with EEVEE.